### PR TITLE
Allow selecting current location marker

### DIFF
--- a/library/src/com/cyrilmottier/polaris/PolarisMapView.java
+++ b/library/src/com/cyrilmottier/polaris/PolarisMapView.java
@@ -640,6 +640,10 @@ public class PolarisMapView extends MapView {
      * @param annotationMarker The default marker
      */
     public void setAnnotations(List<Annotation> annotations, Drawable annotationMarker) {
+        //Remove opened callauts before inserting annotations
+        if (mAnnotationsOverlay != null)
+    		mAnnotationsOverlay.setSelectedAnnotation(INVALID_POSITION);
+
         if (annotations == null) {
             mOverlayContainer.setAnnotationsOverlay(null);
         } else {

--- a/library/src/com/cyrilmottier/polaris/PolarisMapView.java
+++ b/library/src/com/cyrilmottier/polaris/PolarisMapView.java
@@ -490,7 +490,7 @@ public class PolarisMapView extends MapView {
     /**
      * Set a new {@link OnMapViewLongClickListener}.
      * 
-     * @param listener The new {@link OnMapViewLongClickListener}
+     * @param l The new {@link OnMapViewLongClickListener}
      */
     public void setOnMapViewLongClickListener(OnMapViewLongClickListener l) {
         mOnMapViewLongClickListener = l;

--- a/library/src/com/cyrilmottier/polaris/PolarisMapView.java
+++ b/library/src/com/cyrilmottier/polaris/PolarisMapView.java
@@ -16,6 +16,7 @@
 package com.cyrilmottier.polaris;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import android.annotation.TargetApi;
@@ -295,7 +296,7 @@ public class PolarisMapView extends MapView {
     private MapCalloutView mMapCallouts[] = new MapCalloutView[2];
     private int mMapCalloutIndex;
 
-    private Annotation mCurrentLocationOverlay;
+    private Annotation mCurrentLocationAnnotation;
     private String mCurrentLocationTitle;
     private String mCurrentLocationSubtitle;
 
@@ -551,12 +552,16 @@ public class PolarisMapView extends MapView {
                     @Override
                     public void onCurrentLocationChanged(Location location) {
                         final GeoPoint p = new GeoPoint((int) (location.getLatitude() * 1E6), (int) (location.getLongitude() * 1E6));
-                        if(mCurrentLocationOverlay != null)
-                            mAnnotationsOverlay.removeAnnotation(mCurrentLocationOverlay);
+                        if(mCurrentLocationAnnotation != null)
+                            mAnnotationsOverlay.removeAnnotation(mCurrentLocationAnnotation);
 
                         ColorDrawable blankMarker = new ColorDrawable(Color.TRANSPARENT);
-                        mCurrentLocationOverlay = new Annotation(p, mCurrentLocationTitle, mCurrentLocationSubtitle, blankMarker);
-                        mAnnotationsOverlay.addAnnotation(mCurrentLocationOverlay);
+                        mCurrentLocationAnnotation = new Annotation(p, mCurrentLocationTitle, mCurrentLocationSubtitle, blankMarker);
+                        if(mAnnotationsOverlay == null) {
+                            setAnnotations(Collections.singletonList(mCurrentLocationAnnotation), blankMarker);
+                        } else {
+                            mAnnotationsOverlay.addAnnotation(mCurrentLocationAnnotation);
+                        }
                     }
                 });
 
@@ -639,6 +644,9 @@ public class PolarisMapView extends MapView {
             mOverlayContainer.setAnnotationsOverlay(null);
         } else {
             mAnnotationsOverlay = new AnnotationsOverlay(mMystiqueCallback, new ArrayList<Annotation>(annotations), annotationMarker);
+            if(mCurrentLocationAnnotation != null)
+                mAnnotationsOverlay.addAnnotation(mCurrentLocationAnnotation);
+
             mOverlayContainer.setAnnotationsOverlay(mAnnotationsOverlay);
         }
         // Reflect the changes in the MapView

--- a/library/src/com/cyrilmottier/polaris/PolarisMapView.java
+++ b/library/src/com/cyrilmottier/polaris/PolarisMapView.java
@@ -90,7 +90,7 @@ import com.google.android.maps.OverlayItem;
  * <p>Most (or should I say all) map-based applications uses 9-patches as map callout background.
  * While 9-patches are great in most cases, it doesn't allow variable stretching of stretchable areas.
  * In general, the Polaris library contains default resources and more specifically 
- * {@link MapViewCallout}. {@link MapViewCallout} allows variable positioning of the anchor. This 
+ * {@link MapCalloutView}. {@link MapCalloutView} allows variable positioning of the anchor. This
  * improvement is largely used by the Polaris library to get a more polished map. While most 
  * applications center the map on the tapped {@link OverlayItem}, {@link PolarisMapView} shows a
  * map callout trying to reduce scrolling as much as possible. The map is actually scrolled only there

--- a/library/src/com/cyrilmottier/polaris/PolarisMyLocationOverlay.java
+++ b/library/src/com/cyrilmottier/polaris/PolarisMyLocationOverlay.java
@@ -1,0 +1,58 @@
+package com.cyrilmottier.polaris;
+
+import android.content.Context;
+import android.location.Location;
+import android.widget.Toast;
+import com.google.android.maps.GeoPoint;
+import com.google.android.maps.MapView;
+import com.google.android.maps.MyLocationOverlay;
+
+public class PolarisMyLocationOverlay extends MyLocationOverlay {
+
+    private OnCurrentLocationClickListener mOnCurrentLocationClickListener;
+    private OnCurrentLocationChangedListener mOnCurrentLocationChangedListener;
+
+    public PolarisMyLocationOverlay(Context context, MapView mapView) {
+        super(context, mapView);
+    }
+
+    @Override
+    protected boolean dispatchTap() {
+        GeoPoint p = this.getMyLocation();
+
+        if(mOnCurrentLocationClickListener != null)
+            mOnCurrentLocationClickListener.onCurrentLocationClick(p);
+        return true;
+    }
+
+    @Override
+    public synchronized void onLocationChanged(Location location) {
+        super.onLocationChanged(location);
+        if(mOnCurrentLocationChangedListener != null)
+            mOnCurrentLocationChangedListener.onCurrentLocationChanged(location);
+    }
+
+    public void setOnCurrentLocationClickListener(OnCurrentLocationClickListener mOnCurrentLocationClickListener) {
+        this.mOnCurrentLocationClickListener = mOnCurrentLocationClickListener;
+    }
+
+    public OnCurrentLocationClickListener getOnCurrentLocationClickListener() {
+        return mOnCurrentLocationClickListener;
+    }
+
+    public OnCurrentLocationChangedListener getOnCurrentLocationChangedListener() {
+        return mOnCurrentLocationChangedListener;
+    }
+
+    public void setOnCurrentLocationChangedListener(OnCurrentLocationChangedListener listener) {
+        mOnCurrentLocationChangedListener = listener;
+    }
+
+    public static interface OnCurrentLocationClickListener {
+        public void onCurrentLocationClick(GeoPoint point);
+    }
+
+    public static interface OnCurrentLocationChangedListener {
+        public void onCurrentLocationChanged(Location location);
+    }
+}

--- a/library/src/com/cyrilmottier/polaris/internal/AnnotationsOverlay.java
+++ b/library/src/com/cyrilmottier/polaris/internal/AnnotationsOverlay.java
@@ -85,6 +85,27 @@ public class AnnotationsOverlay extends ItemizedOverlay<Annotation> {
         return mAnnotations.get(index);
     }
 
+    public void addAnnotation(Annotation a) {
+        mAnnotations.add(a);
+        populate();
+    }
+
+    public void removeAnnotation(Annotation a) {
+        final int index = indexOf(a);
+        if(index != INVALID_POSITION) {
+            mAnnotations.remove(index);
+            populate();
+        }
+    }
+
+    private int indexOf(Annotation a) {
+        for(int i = 0, size = mAnnotations.size(); i < size; i++)
+            if(a == mAnnotations.get(i))
+                return i;
+
+        return INVALID_POSITION;
+    }
+
     public int getSelectedAnnotation() {
         return mSelectedAnnotation;
     }


### PR DESCRIPTION
Often its useful for users to be able to click on the current location overlay. These changes creating a new annotation (with a blank marker) on the MyLocationOverlay if enabled.
