### PR TITLE
Fix when you have Annotations and other overlays on the same mapView

### DIFF
--- a/library/src/com/cyrilmottier/polaris/internal/OverlayContainer.java
+++ b/library/src/com/cyrilmottier/polaris/internal/OverlayContainer.java
@@ -63,7 +63,7 @@ public class OverlayContainer extends Overlay {
                     break;
 
                 case 1:
-                    if (hasAnnotationsOverlay) {
+                    if (hasLocationOverlay && hasAnnotationsOverlay) {
                         return mAnnotationsOverlay;
                     }
                     break;


### PR DESCRIPTION
Some overlays were not drawn when you mixed Annotations and other overlays.
