### PR TITLE
Map callout doesn't disappear if annotation is removed

### DIFF
--- a/library/src/com/cyrilmottier/polaris/PolarisMapView.java
+++ b/library/src/com/cyrilmottier/polaris/PolarisMapView.java
@@ -609,6 +609,10 @@ public class PolarisMapView extends MapView {
      * @param annotationMarker The default marker
      */
     public void setAnnotations(List<Annotation> annotations, Drawable annotationMarker) {
+        //Remove opened callauts before inserting annotations
+        if (mAnnotationsOverlay != null)
+    		mAnnotationsOverlay.setSelectedAnnotation(INVALID_POSITION);
+
         if (annotations == null) {
             mOverlayContainer.setAnnotationsOverlay(null);
         } else {

--- a/library/src/com/cyrilmottier/polaris/PolarisMapView.java
+++ b/library/src/com/cyrilmottier/polaris/PolarisMapView.java
@@ -609,9 +609,10 @@ public class PolarisMapView extends MapView {
      * @param annotationMarker The default marker
      */
     public void setAnnotations(List<Annotation> annotations, Drawable annotationMarker) {
-        //Remove opened callauts before inserting annotations
-        if (mAnnotationsOverlay != null)
+        // Remove opened callouts before inserting annotations
+        if (mAnnotationsOverlay != null) {
     		mAnnotationsOverlay.setSelectedAnnotation(INVALID_POSITION);
+        }
 
         if (annotations == null) {
             mOverlayContainer.setAnnotationsOverlay(null);


### PR DESCRIPTION
If the user clicks on an annotation a callout appears.
If the annotation is removed before than the callout has been removed (ie if the user doesn't click on the map), the callout will not disappear while clicking on the map. It will be dismissed only when the user clicks on another annotation, in which case a new callout will be displayed.

This happens frequently while using OnRegionChangedListener (or onRegionChangeConfirmed) for lazyloading:
- the user click on an annotation
- the user scrolls the map
- annotations are recreated
- an orphan callout is born.

Proposed patch Remove the opened callout before inserting new annotations.
