### PR TITLE
Cosmetic code fixes

### DIFF
--- a/library/src/com/cyrilmottier/polaris/Annotation.java
+++ b/library/src/com/cyrilmottier/polaris/Annotation.java
@@ -56,7 +56,7 @@ public class Annotation extends OverlayItem {
      * @param title Title text for this annotation
      * @param snippet Snippet text for this annotation
      * @param marker Drawable used as this {@link Annotation}'s marker (please
-     *            note this marker must have its bounds already set. You canuse
+     *            note this marker must have its bounds already set. You can use
      *            the {@link MapViewUtils#boundMarker(Drawable, int)} utility
      *            method to prepare this {@link Drawable}'s bounds)
      */

--- a/library/src/com/cyrilmottier/polaris/CoordinateRegion.java
+++ b/library/src/com/cyrilmottier/polaris/CoordinateRegion.java
@@ -74,7 +74,7 @@ public class CoordinateRegion {
      * Create a new region, initialized with the values in the specified region
      * (which is left unmodified).
      * 
-     * @param r The region whose coordinates are copied into this region.
+     * @param region The region whose coordinates are copied into this region.
      */
     public CoordinateRegion(CoordinateRegion region) {
         this.latitude = region.latitude;
@@ -140,7 +140,7 @@ public class CoordinateRegion {
     /**
      * Copy the coordinates into this {@link CoordinateRegion}.
      * 
-     * @param src The region whose coordinates are copied into this region
+     * @param region The region whose coordinates are copied into this region
      */
     public void set(CoordinateRegion region) {
         latitude = region.latitude;

--- a/library/src/com/cyrilmottier/polaris/MapCalloutView.java
+++ b/library/src/com/cyrilmottier/polaris/MapCalloutView.java
@@ -316,10 +316,10 @@ public class MapCalloutView extends ViewGroup {
     }
 
     /**
-     * Set the title of the {@link MapViewCallout}. The {@link MapViewCallout}
+     * Set the title of the {@link MapCalloutView}. The {@link MapCalloutView}
      * automatically manages empty (null or zero-length) title.
      * 
-     * @param title The title to apply to this {@link MapViewCallout}
+     * @param title The title to apply to this {@link MapCalloutView}
      */
     public void setTitle(CharSequence title) {
         if (!TextUtils.isEmpty(title)) {
@@ -331,11 +331,11 @@ public class MapCalloutView extends ViewGroup {
     }
 
     /**
-     * Set the subtitle of the {@link MapViewCallout}. The
-     * {@link MapViewCallout} automatically manages empty (null or zero-length)
+     * Set the subtitle of the {@link MapCalloutView}. The
+     * {@link MapCalloutView} automatically manages empty (null or zero-length)
      * subtitle.
      * 
-     * @param subtitle The subtitle to apply to this {@link MapViewCallout}
+     * @param subtitle The subtitle to apply to this {@link MapCalloutView}
      */
     public void setSubtitle(CharSequence subtitle) {
         if (!TextUtils.isEmpty(subtitle)) {
@@ -373,7 +373,7 @@ public class MapCalloutView extends ViewGroup {
 
     /**
      * Enable or disable the disclosure indicator. Put simple, the disclosure
-     * indicator should always be visible when the {@link MapViewCallout} is
+     * indicator should always be visible when the {@link MapCalloutView} is
      * clickable i.e. when an action such as "opening" a details screen is done
      * on click.
      * 
@@ -400,7 +400,7 @@ public class MapCalloutView extends ViewGroup {
     }
 
     /**
-     * Set a new right accessory view to this {@link MapViewCallout}. The newly
+     * Set a new right accessory view to this {@link MapCalloutView}. The newly
      * added view will remove the previous one. Setting
      * {@link android.view.ViewGroup.LayoutParams} to the given right accessory
      * is not necessary as they will be automatically set to (
@@ -455,7 +455,7 @@ public class MapCalloutView extends ViewGroup {
     }
 
     /**
-     * Set a new left accessory view to this {@link MapViewCallout}. The newly
+     * Set a new left accessory view to this {@link MapCalloutView}. The newly
      * added view will remove the previous one. Setting
      * {@link android.view.ViewGroup.LayoutParams} to the given left accessory
      * is not necessary as they will be automatically set to (
@@ -500,9 +500,9 @@ public class MapCalloutView extends ViewGroup {
     }
 
     /**
-     * Set a new custom view to this {@link MapViewCallout}. The newly added
+     * Set a new custom view to this {@link MapCalloutView}. The newly added
      * view will remove the previous one. Custom views are usually used to
-     * completely manage the content of the {@link MapViewCallout}. Setting
+     * completely manage the content of the {@link MapCalloutView}. Setting
      * {@link android.view.ViewGroup.LayoutParams} to the given left accessory
      * is not necessary as they will be automatically set to (
      * {@link android.view.ViewGroup.LayoutParams#WRAP_CONTENT},
@@ -534,7 +534,7 @@ public class MapCalloutView extends ViewGroup {
     }
 
     /**
-     * Indicates whether this {@link MapViewCallout} has some displayable
+     * Indicates whether this {@link MapCalloutView} has some displayable
      * content. The result of this method is used as a hint to know whether or
      * not the callout should be displayed once an {@link Annotation} has been
      * applied to it.

--- a/library/src/com/cyrilmottier/polaris/MapCalloutView.java
+++ b/library/src/com/cyrilmottier/polaris/MapCalloutView.java
@@ -123,7 +123,7 @@ public class MapCalloutView extends ViewGroup {
 
         mTitle = (TextView) findViewById(R.id.polaris__title);
         mSubtitle = (TextView) findViewById(R.id.polaris__subtitle);
-        mDisclosure = (ImageView) findViewById(R.id.polaris__disclosure);
+        mDisclosure = findViewById(R.id.polaris__disclosure);
         mContentContainer = (FrameLayout) findViewById(R.id.polaris__content_container);
         mContent = findViewById(R.id.polaris__content);
     }

--- a/library/src/com/cyrilmottier/polaris/MapCalloutView.java
+++ b/library/src/com/cyrilmottier/polaris/MapCalloutView.java
@@ -508,7 +508,7 @@ public class MapCalloutView extends ViewGroup {
      * {@link android.view.ViewGroup.LayoutParams#WRAP_CONTENT},
      * {@link android.view.ViewGroup.LayoutParams#WRAP_CONTENT}).
      * 
-     * @param customView The new left accessory view.
+     * @param customView The new custom view.
      */
     public void setCustomView(View customView) {
         if (customView != null && customView.getParent() != null) {

--- a/library/src/com/cyrilmottier/polaris/MapCalloutView.java
+++ b/library/src/com/cyrilmottier/polaris/MapCalloutView.java
@@ -307,7 +307,7 @@ public class MapCalloutView extends ViewGroup {
     }
 
     /**
-     * Set a new lister to listen to double tap events.
+     * Set a new listener to listen to double tap events.
      * 
      * @param l The listener to set
      */

--- a/library/src/com/cyrilmottier/polaris/MapCalloutView.java
+++ b/library/src/com/cyrilmottier/polaris/MapCalloutView.java
@@ -462,7 +462,7 @@ public class MapCalloutView extends ViewGroup {
      * {@link android.view.ViewGroup.LayoutParams#WRAP_CONTENT},
      * {@link android.view.ViewGroup.LayoutParams#WRAP_CONTENT}).
      * 
-     * @param rightAccessoryView The new left accessory view.
+     * @param leftAccessoryView The new left accessory view.
      */
     public void setLeftAccessoryView(View leftAccessoryView) {
         if (leftAccessoryView != null && leftAccessoryView.getParent() != null) {
@@ -508,7 +508,7 @@ public class MapCalloutView extends ViewGroup {
      * {@link android.view.ViewGroup.LayoutParams#WRAP_CONTENT},
      * {@link android.view.ViewGroup.LayoutParams#WRAP_CONTENT}).
      * 
-     * @param rightAccessoryView The new left accessory view.
+     * @param customView The new left accessory view.
      */
     public void setCustomView(View customView) {
         if (customView != null && customView.getParent() != null) {

--- a/library/src/com/cyrilmottier/polaris/MapCalloutView.java
+++ b/library/src/com/cyrilmottier/polaris/MapCalloutView.java
@@ -679,7 +679,7 @@ public class MapCalloutView extends ViewGroup {
 
         public void onLongPress(MotionEvent e) {
             mHasLongPressed = true;
-        };
+        }
 
         @Override
         public boolean onDoubleTap(MotionEvent e) {
@@ -688,5 +688,5 @@ public class MapCalloutView extends ViewGroup {
             }
             return true;
         }
-    };
+    }
 }

--- a/library/src/com/cyrilmottier/polaris/MapViewUtils.java
+++ b/library/src/com/cyrilmottier/polaris/MapViewUtils.java
@@ -82,7 +82,7 @@ public final class MapViewUtils {
      * @param mapView The {@link MapView} to animate
      * @param myLocationOverlay The {@link MyLocationOverlay} whose location
      *            will be used to determine the user location.
-     * @param errorMessageId The message to display in case no location is
+     * @param errorMessage The message to display in case no location is
      *            available.
      */
     public static void smoothCenterOnUserLocation(MapView mapView, MyLocationOverlay myLocationOverlay, String errorMessage) {

--- a/library/src/com/cyrilmottier/polaris/PolarisMapView.java
+++ b/library/src/com/cyrilmottier/polaris/PolarisMapView.java
@@ -490,7 +490,7 @@ public class PolarisMapView extends MapView {
     /**
      * Set a new {@link OnMapViewLongClickListener}.
      * 
-     * @param listener The new {@link OnMapViewLongClickListener}
+     * @param l The new {@link OnMapViewLongClickListener}
      */
     public void setOnMapViewLongClickListener(OnMapViewLongClickListener l) {
         mOnMapViewLongClickListener = l;

--- a/library/src/com/cyrilmottier/polaris/PolarisMapView.java
+++ b/library/src/com/cyrilmottier/polaris/PolarisMapView.java
@@ -90,7 +90,7 @@ import com.google.android.maps.OverlayItem;
  * <p>Most (or should I say all) map-based applications uses 9-patches as map callout background.
  * While 9-patches are great in most cases, it doesn't allow variable stretching of stretchable areas.
  * In general, the Polaris library contains default resources and more specifically 
- * {@link MapViewCallout}. {@link MapViewCallout} allows variable positioning of the anchor. This 
+ * {@link MapCalloutView}. {@link MapCalloutView} allows variable positioning of the anchor. This
  * improvement is largely used by the Polaris library to get a more polished map. While most 
  * applications center the map on the tapped {@link OverlayItem}, {@link PolarisMapView} shows a
  * map callout trying to reduce scrolling as much as possible. The map is actually scrolled only there

--- a/library/src/com/cyrilmottier/polaris/internal/OverlayContainer.java
+++ b/library/src/com/cyrilmottier/polaris/internal/OverlayContainer.java
@@ -78,7 +78,7 @@ public class OverlayContainer extends Overlay {
             }
 
             return super.get(reindex);
-        };
+        }
 
         @Override
         public int size() {
@@ -90,7 +90,7 @@ public class OverlayContainer extends Overlay {
                 size++;
             }
             return size;
-        };
+        }
     };
 
     private final GestureDetector mGestureDetector;
@@ -233,7 +233,7 @@ public class OverlayContainer extends Overlay {
 
         public void onLongPress(MotionEvent e) {
             mCallback.onLongPress(e);
-        };
+        }
 
         @Override
         public boolean onDoubleTap(MotionEvent e) {


### PR DESCRIPTION
Some changes that could be completely useless :-)

There are other questions that are not included in request now.
1. Method parameters have different forms (for example [here](https://github.com/cyrilmottier/Polaris/blob/master/library/src/com/cyrilmottier/polaris/MapCalloutView.java#L147) parameter has full name and [here](https://github.com/cyrilmottier/Polaris/blob/master/library/src/com/cyrilmottier/polaris/MapCalloutView.java#L152) has only one letter).
2. Some `for` loops could be replaced with `foreach` ones: [`OverlayContainer#draw`](https://github.com/cyrilmottier/Polaris/blob/master/library/src/com/cyrilmottier/polaris/internal/OverlayContainer.java#L113) and [another `OverlayContainer#draw`](https://github.com/cyrilmottier/Polaris/blob/master/library/src/com/cyrilmottier/polaris/internal/OverlayContainer.java#L121).
3. Seems like javadocs for [`MapCalloutView#setMarkerHeight`](https://github.com/cyrilmottier/Polaris/blob/master/library/src/com/cyrilmottier/polaris/MapCalloutView.java#L577) and [`MapCalloutView#getMarkerHeight`](https://github.com/cyrilmottier/Polaris/blob/master/library/src/com/cyrilmottier/polaris/MapCalloutView.java#L567) are incorrect.
